### PR TITLE
Pylint fixes

### DIFF
--- a/pirogue_admin/cmd/cli.py
+++ b/pirogue_admin/cmd/cli.py
@@ -33,7 +33,8 @@ def check_consistency(c_ctx: ConfigurationContext):
     print(loader.configs)
     #print(loader.get_needed_variables())
     #print(loader.variables)
-    needed = [x for x in loader.get_needed_variables() if x not in loader.variables and x not in loader.current_config]
+    needed = [x for x in loader.get_needed_variables()
+              if x not in loader.variables and x not in loader.current_config]
     #print(needed)
 
     pretty_print_map = {
@@ -43,7 +44,10 @@ def check_consistency(c_ctx: ConfigurationContext):
         'remain_needed': needed,
         'currents': loader.current_config,
     }
-    yaml.safe_dump(pretty_print_map, sys.stdout, default_flow_style=False, encoding="utf-8", allow_unicode=True)
+    yaml.safe_dump(pretty_print_map, sys.stdout,
+                   default_flow_style=False,
+                   encoding="utf-8",
+                   allow_unicode=True)
 
 
 def autodetect_settings(c_ctx: ConfigurationContext):
@@ -166,11 +170,13 @@ def main():
                         The current configuration is written to an optional file or stdout (default).
                         The current configuration is a set of "KEY: 'value'" pairs.''')
     parser.add_argument('--commit', action='store_true',
-                        help='disable dry-run mode and commit changes (writing system files and executing hooks)')
+                        help='''disable dry-run mode and commit changes (writing system files and
+                        executing hooks)''')
 
     args = parser.parse_args()
 
-    c_ctx = ConfigurationContext(WORKING_ROOT_DIR, ADMIN_CONFIG_DIR, ADMIN_VAR_DIR, args.commit, args.from_scratch)
+    c_ctx = ConfigurationContext(WORKING_ROOT_DIR, ADMIN_CONFIG_DIR, ADMIN_VAR_DIR,
+                                 args.commit, args.from_scratch)
 
     if args.check:
         check_consistency(c_ctx)

--- a/pirogue_admin/cmd/cli.py
+++ b/pirogue_admin/cmd/cli.py
@@ -9,7 +9,6 @@ Known limitations:
 import argparse
 import os
 import sys
-from pathlib import Path
 from typing import TextIO
 
 import yaml

--- a/pirogue_admin/cmd/cli.py
+++ b/pirogue_admin/cmd/cli.py
@@ -151,13 +151,13 @@ def main():
     parser.add_argument('--apply',
                         action='store', nargs='?', type=argparse.FileType('r'),
                         default=argparse.SUPPRESS,
-                        help='''applies a new configuration to the system.
+                        help='''apply a new configuration to the system.
                         Configuration is read from an optional input file or stdin (default).
                         Configuration is a set of "KEY: 'value'" pairs''')
     parser.add_argument('--configuration-tree', '--tree', '-t',
                         action='store', nargs='?', type=argparse.FileType('w'),
                         default=argparse.SUPPRESS,
-                        help='''generates a configuration tree map, describing this pirogue instance.
+                        help='''generate a configuration tree map, describing this pirogue instance.
                         The descriptive tree is written to an optional file or stdout (default).''')
     parser.add_argument('--current-config', '--config',
                         action='store', nargs='?', type=argparse.FileType('w'),
@@ -166,7 +166,7 @@ def main():
                         The current configuration is written to an optional file or stdout (default).
                         The current configuration is a set of "KEY: 'value'" pairs.''')
     parser.add_argument('--commit', action='store_true',
-                        help='Disable dry-run mode and commit changes (writing system files and executing hooks)')
+                        help='disable dry-run mode and commit changes (writing system files and executing hooks)')
 
     args = parser.parse_args()
 

--- a/pirogue_admin/package_config/__init__.py
+++ b/pirogue_admin/package_config/__init__.py
@@ -334,11 +334,8 @@ class PackageConfigLoader:
                     raise ValueError(f'default variable {variable} redefined in {config.package}')
                 self.variables[variable] = value
 
+        # Load current config based on CLI flags and on config file's presence:
         self.current_config: dict[str, str] = {}
-        self.load_current_configuration_state()
-
-    def load_current_configuration_state(self):
-
         if self.ctx.from_scratch:
             print('Loading current config (from scratch): empty')
             return

--- a/pirogue_admin/package_config/__init__.py
+++ b/pirogue_admin/package_config/__init__.py
@@ -11,7 +11,6 @@ import hashlib
 import os
 import shlex
 import subprocess
-from io import TextIOWrapper
 from pathlib import Path
 from dataclasses import dataclass
 from typing import TextIO

--- a/pirogue_admin/package_config/__init__.py
+++ b/pirogue_admin/package_config/__init__.py
@@ -361,10 +361,10 @@ class PackageConfigLoader:
 
         :return a dictionary structure of the configuration
         """
-        by_package = dict()
-        by_file = dict()
-        by_variable = dict()
-        by_action = dict()
+        by_package = {}
+        by_file = {}
+        by_variable = {}
+        by_action = {}
 
         for s in self.configs:
             by_package[s.package] = {

--- a/pirogue_admin/package_config/__init__.py
+++ b/pirogue_admin/package_config/__init__.py
@@ -71,8 +71,7 @@ class ConfigurationContext:
         """
         if self.dry_run:
             return ConfigurationContext.path_concat(os.getcwd(), 'dry-run')
-        else:
-            return self.pirogue_working_root_dir
+        return self.pirogue_working_root_dir
 
     @property
     def admin_dir(self) -> str:
@@ -97,8 +96,7 @@ class ConfigurationContext:
         """
         if self.dry_run:
             return ConfigurationContext.path_concat(self.root_dir, self.pirogue_var_dir)
-        else:
-            return self.var_dir
+        return self.var_dir
 
     def __repr__(self):
         return f"ConfigurationContext(" \

--- a/pirogue_admin/package_config/__init__.py
+++ b/pirogue_admin/package_config/__init__.py
@@ -361,6 +361,7 @@ class PackageConfigLoader:
 
         :return a dictionary structure of the configuration
         """
+        # Accept (very) short names in this function => pylint: disable=invalid-name
         by_package = {}
         by_file = {}
         by_variable = {}

--- a/pirogue_admin/package_config/__init__.py
+++ b/pirogue_admin/package_config/__init__.py
@@ -79,7 +79,8 @@ class ConfigurationContext:
         Returns the PiRogue share/admin directory depending on the current
         PIROGUE_WORKING_ROOT_DIR configuration.
         """
-        return ConfigurationContext.path_concat(self.pirogue_working_root_dir, self.pirogue_admin_dir)
+        return ConfigurationContext.path_concat(self.pirogue_working_root_dir,
+                                                self.pirogue_admin_dir)
 
     @property
     def var_dir(self) -> str:
@@ -87,7 +88,8 @@ class ConfigurationContext:
         Returns the PiRogue var/admin directory depending on the current
         PIROGUE_WORKING_ROOT_DIR configuration.
         """
-        return ConfigurationContext.path_concat(self.pirogue_working_root_dir, self.pirogue_var_dir)
+        return ConfigurationContext.path_concat(self.pirogue_working_root_dir,
+                                                self.pirogue_var_dir)
 
     @property
     def write_var_dir(self) -> str:
@@ -324,7 +326,8 @@ class PackageConfigLoader:
         self.ctx = ctx
 
         self.configs: list[PackageConfig] = []
-        for item in [path for path in Path(self.ctx.admin_dir).glob('*') if path.is_dir() or path.is_symlink()]:
+        for item in [path for path in Path(self.ctx.admin_dir).glob('*')
+                     if path.is_dir() or path.is_symlink()]:
             self.configs.append(PackageConfig(self.ctx, item))
 
         self.variables: dict[str, str] = {}
@@ -419,7 +422,8 @@ class PackageConfigLoader:
         # FIXME: Find a way to avoid set() conversion to list()
         # yaml dumps set()s differently than list()s:
         # yaml appends '!!set' keyword to all set() dumps
-        # it should be possible to tweak yaml.dump invocation with some arguments to avoid this behavior.
+        # it should be possible to tweak yaml.dump invocation with some arguments to avoid this
+        # behavior.
         for s in whole_map:
             for k in whole_map[s]:
                 for fk in whole_map[s][k]:
@@ -430,9 +434,12 @@ class PackageConfigLoader:
 
     def dump_current_configuration(self, output: TextIO, notice_preamble: bool = False):
         """
-        Writes the current configuration set to the given output stream. Can write user notice as header in the dump.
+        Writes the current configuration set to the given output stream. Can
+        write user notice as header in the dump.
+
         :param output: a valid text output stream
         :param notice_preamble: appends a 'dot not edit' user header notice if True
+
         """
         if notice_preamble:
             output.write('# This file is generated\n')
@@ -477,7 +484,8 @@ class PackageConfigLoader:
             raise ValueError(f'missing variables: {missing}')
 
         if self.ctx.dry_run:
-            print(f'notice: in dry-run mode, all files will be written locally to: {self.ctx.root_dir}')
+            print(f'notice: in dry-run mode, all files will be written locally to: '
+                  f'{self.ctx.root_dir}')
 
         # Iterate over AdminConfig instances sorting them alphabetically, but we
         # could introduce some priority/order if needed:

--- a/pirogue_admin/package_config/__init__.py
+++ b/pirogue_admin/package_config/__init__.py
@@ -350,8 +350,8 @@ class PackageConfigLoader:
 
         loaded_current_config = yaml.safe_load(current_config_path.read_text())
         if isinstance(loaded_current_config, dict):  # Prevents existing but empty file
-            for k, v in loaded_current_config.items():
-                self.current_config[k] = v
+            for key, value in loaded_current_config.items():
+                self.current_config[key] = value
 
         print('Loading current config:', self.current_config)
 


### PR DESCRIPTION
Hello @TontonSancho, and thanks for your initial work on `ConfigurationContext` and friends in `pirogue-admin`.

Since `pylint` got triggered a little more than before (with mostly `FIXME`s that should stay on my/our radar), I'm tempted to get a few things or marked as “not being an issue” (e.g. `disable=invalid-name` when one-letter variable names are used).

I'm not pushing this directly to the main branch as you might have pending work. If that's the case, please push and let me know, I'll deal with rebasing etc.