### PR TITLE
Add pirogue-admin-api to Build-Depends.

### DIFF
--- a/pirogue-admin/debian/control
+++ b/pirogue-admin/debian/control
@@ -5,6 +5,7 @@ Maintainer: U+039b <hello@pts-project.org>
 Build-Depends:
  debhelper-compat (= 13),
  dh-python,
+ pirogue-admin-api,
  python3-all,
  python3-grpcio,
  python3-setuptools,


### PR DESCRIPTION
At the moment it's required during the build. Otherwise, the test suite errors out with:

    ModuleNotFoundError: No module named 'pirogue_admin_api'